### PR TITLE
对翻译流程修改，在调用谷歌翻译之前做判断是否可以用谷歌翻译，不行的话用AI翻译

### DIFF
--- a/src/main/java/com/bogdatech/controller/TestController.java
+++ b/src/main/java/com/bogdatech/controller/TestController.java
@@ -12,6 +12,7 @@ import com.bogdatech.model.controller.request.CloudServiceRequest;
 import com.bogdatech.model.controller.request.ShopifyRequest;
 import com.bogdatech.model.controller.request.TranslateRequest;
 import com.bogdatech.utils.CharacterCountUtils;
+import com.bogdatech.utils.JsoupUtils;
 import com.microsoft.applicationinsights.TelemetryClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -27,14 +28,16 @@ public class TestController {
     private final ShopifyHttpIntegration shopifyApiIntegration;
     private final TestService testService;
     private final TranslateService translateService;
+    private final JsoupUtils jsoupUtils;
 
     @Autowired
-    public TestController(TranslatesServiceImpl translatesServiceImpl, ChatGptIntegration chatGptIntegration, ShopifyHttpIntegration shopifyApiIntegration, TestService testService, TranslateService translateService) {
+    public TestController(TranslatesServiceImpl translatesServiceImpl, ChatGptIntegration chatGptIntegration, ShopifyHttpIntegration shopifyApiIntegration, TestService testService, TranslateService translateService, JsoupUtils jsoupUtils) {
         this.translatesServiceImpl = translatesServiceImpl;
         this.chatGptIntegration = chatGptIntegration;
         this.shopifyApiIntegration = shopifyApiIntegration;
         this.testService = testService;
         this.translateService = translateService;
+        this.jsoupUtils = jsoupUtils;
     }
 //	@GetMapping("/test")
 //	public List<JdbcTestModel> test() {
@@ -94,10 +97,6 @@ public class TestController {
         LocalDateTime localDateTime = LocalDateTime.now();
         translateService.translateSuccessEmail(new TranslateRequest(0, "ciwishop.myshopify.com", null, "en", "zh-CN", null), characterCount, localDateTime, 0, 12311);
     }
-//    //获取tokens里面的数据
-//    @GetMapping("/getToken")
-//    public void getToken() {
-//        System.out.println("tokens: " + tokens.toString());
-//    }
+
 
 }

--- a/src/main/java/com/bogdatech/controller/TranslateController.java
+++ b/src/main/java/com/bogdatech/controller/TranslateController.java
@@ -2,6 +2,7 @@ package com.bogdatech.controller;
 
 import com.bogdatech.Service.ITranslatesService;
 import com.bogdatech.Service.ITranslationCounterService;
+import com.bogdatech.entity.AILanguagePacksDO;
 import com.bogdatech.entity.TranslatesDO;
 import com.bogdatech.entity.TranslationCounterDO;
 import com.bogdatech.integration.ShopifyHttpIntegration;
@@ -9,6 +10,7 @@ import com.bogdatech.logic.TranslateService;
 import com.bogdatech.model.controller.request.*;
 import com.bogdatech.model.controller.response.BaseResponse;
 import com.bogdatech.utils.CharacterCountUtils;
+import com.bogdatech.utils.JsoupUtils;
 import com.microsoft.applicationinsights.TelemetryClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -27,20 +29,22 @@ public class TranslateController {
     private final ITranslatesService translatesService;
     private final ShopifyHttpIntegration shopifyApiIntegration;
     private final ITranslationCounterService translationCounterService;
-
+    private final JsoupUtils jsoupUtils;
 
     @Autowired
     public TranslateController(
             TranslateService translateService,
             ITranslatesService translatesService,
             ShopifyHttpIntegration shopifyApiIntegration,
-            ITranslationCounterService translationCounterService
-    ) {
+            ITranslationCounterService translationCounterService,
+
+            JsoupUtils jsoupUtils) {
         this.translateService = translateService;
         this.translatesService = translatesService;
         this.shopifyApiIntegration = shopifyApiIntegration;
         this.translationCounterService = translationCounterService;
 
+        this.jsoupUtils = jsoupUtils;
     }
 
     private TelemetryClient appInsights = new TelemetryClient();
@@ -60,6 +64,22 @@ public class TranslateController {
     @PostMapping("/googleTranslate")
     public String googleTranslate(@RequestBody TranslateRequest request) {
         return translateService.googleTranslate(request);
+
+    }
+
+    /*
+     * 调用判断语言的翻译接口
+     */
+    @PostMapping("/judgeLanguage")
+    public List<String> judgeLanguage(@RequestBody GoogleAndAIRequest request) {
+        TranslateRequest translateRequest = new TranslateRequest();
+        translateRequest.setContent(request.getContent());
+        translateRequest.setSource(request.getSource());
+        translateRequest.setTarget(request.getTarget());
+        AILanguagePacksDO aiLanguagePacksDO = new AILanguagePacksDO();
+        aiLanguagePacksDO.setPromotWord(request.getPromotWord());
+        aiLanguagePacksDO.setDeductionRate(request.getDeductionRate());
+        return jsoupUtils.googleTranslateJudgeCode(translateRequest, aiLanguagePacksDO);
     }
 
     /*

--- a/src/main/java/com/bogdatech/integration/TranslateApiIntegration.java
+++ b/src/main/java/com/bogdatech/integration/TranslateApiIntegration.java
@@ -98,7 +98,7 @@ public class TranslateApiIntegration {
                 "&source=" + request.getSource() +
                 "&target=" + request.getTarget() +
                 "&model=base";
-        String result;
+        String result = null;
 
         // 创建HttpGet请求
         HttpPost httpPost = new HttpPost(url);
@@ -115,7 +115,7 @@ public class TranslateApiIntegration {
             JSONObject translation = translationsArray.getJSONObject(0);
             result = translation.getString("translatedText");
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            appInsights.trackTrace("翻译错误信息：" + e.getMessage());
         }
         return result;
     }

--- a/src/main/java/com/bogdatech/logic/TranslateService.java
+++ b/src/main/java/com/bogdatech/logic/TranslateService.java
@@ -169,15 +169,13 @@ public class TranslateService {
 
     //封装调用云服务器实现获取谷歌翻译数据的方法
     public String getGoogleTranslateData(TranslateRequest request) {
-
-
         // 使用 ObjectMapper 将对象转换为 JSON 字符串
         ObjectMapper objectMapper = new ObjectMapper();
         String string;
         try {
             String requestBody = objectMapper.writeValueAsString(request);
             string = testingEnvironmentIntegration.sendShopifyPost("translate/googleTranslate", requestBody);
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
 //            throw new RuntimeException(e);
             appInsights.trackTrace("Failed to get Google Translate data: " + e.getMessage());
             return request.getContent();
@@ -193,7 +191,6 @@ public class TranslateService {
             testingEnvironmentIntegration.sendShopifyPost("translate/insertTranslatedText", requestBody);
         } catch (JsonProcessingException | ClientException e) {
             appInsights.trackTrace("Failed to save to Shopify: " + e.getMessage());
-//            throw new ClientException("Failed to deposit locally");
         }
     }
 
@@ -438,7 +435,6 @@ public class TranslateService {
                         translateDataByDatabase(entry.getValue(), translateContext);
                     } catch (Exception e) {
                         appInsights.trackTrace(e.getMessage());
-                        System.out.println(e.getMessage());
                         continue;
                     }
                     break;
@@ -661,7 +657,7 @@ public class TranslateService {
     private void translateDataByDatabase(List<RegisterTransactionRequest> registerTransactionRequests, TranslateContext translateContext) {
         ShopifyRequest request = translateContext.getShopifyRequest();
         CharacterCountUtils counter = translateContext.getCharacterCountUtils();
-
+        AILanguagePacksDO aiLanguagePacksDO = translateContext.getAiLanguagePacksDO();
         //判断是否停止翻译
         if (checkIsStopped(request.getShopName(), counter)) return;
 
@@ -703,7 +699,7 @@ public class TranslateService {
             } catch (Exception e) {
                 //打印错误信息
                 saveToShopify(value, translation, resourceId, request);
-//                appInsights.trackTrace(e.getMessage());
+                appInsights.trackTrace(e.getMessage());
             }
             //数据库为空的逻辑
             //判断数据类型
@@ -731,7 +727,7 @@ public class TranslateService {
                     // 提取需要翻译的文本
                     Map<Element, List<String>> elementTextMap = jsoupUtils.extractTextsToTranslate(doc);
                     // 翻译文本
-                    Map<Element, List<String>> translatedTextMap = jsoupUtils.translateTexts(elementTextMap, translateRequest, counter);
+                    Map<Element, List<String>> translatedTextMap = jsoupUtils.translateTexts(elementTextMap, translateRequest, counter, aiLanguagePacksDO);
                     // 替换原始文本为翻译后的文本
                     jsoupUtils.replaceOriginalTextsWithTranslated(doc, translatedTextMap);
                 } catch (Exception e) {
@@ -744,6 +740,7 @@ public class TranslateService {
 
             counter.addChars(calculateToken(value, 1));
             String targetString;
+            //TODO: 改为判断语言代码方法
             targetString = getGoogleTranslateData(new TranslateRequest(0, null, null, source, target, value));
             addData(target, value, targetString);
             saveToShopify(targetString, translation, resourceId, request);
@@ -756,7 +753,7 @@ public class TranslateService {
     private void translateHtml(List<RegisterTransactionRequest> registerTransactionRequests, TranslateContext translateContext) {
         ShopifyRequest request = translateContext.getShopifyRequest();
         CharacterCountUtils counter = translateContext.getCharacterCountUtils();
-
+        AILanguagePacksDO aiLanguagePacksDO = translateContext.getAiLanguagePacksDO();
         //判断是否停止翻译
         if (checkIsStopped(request.getShopName(), counter)) return;
 
@@ -783,10 +780,9 @@ public class TranslateService {
                 // 提取需要翻译的文本
                 Map<Element, List<String>> elementTextMap = jsoupUtils.extractTextsToTranslate(doc);
                 // 翻译文本
-                Map<Element, List<String>> translatedTextMap = jsoupUtils.translateTexts(elementTextMap, translateRequest, counter);
+                Map<Element, List<String>> translatedTextMap = jsoupUtils.translateTexts(elementTextMap, translateRequest, counter, aiLanguagePacksDO);
                 // 替换原始文本为翻译后的文本
                 jsoupUtils.replaceOriginalTextsWithTranslated(doc, translatedTextMap);
-//                System.out.println("HTML翻译后的数据： " + doc.toString());
             } catch (Exception e) {
                 saveToShopify(doc.toString(), translation, resourceId, request);
                 continue;
@@ -801,6 +797,7 @@ public class TranslateService {
                                     TranslateContext translateContext) {
         ShopifyRequest request = translateContext.getShopifyRequest();
         CharacterCountUtils counter = translateContext.getCharacterCountUtils();
+        AILanguagePacksDO aiLanguagePacksDO = translateContext.getAiLanguagePacksDO();
 
         int remainingChars = translateContext.getRemainingChars();
         String target = request.getTarget();
@@ -808,12 +805,11 @@ public class TranslateService {
         for (RegisterTransactionRequest registerTransactionRequest : registerTransactionRequests) {
             if (checkIsStopped(request.getShopName(), counter)) return;
             String value = registerTransactionRequest.getValue();
-            String source = registerTransactionRequest.getLocale();
             String resourceId = registerTransactionRequest.getResourceId();
 
             Map<String, Object> translation = createTranslationMap(target, registerTransactionRequest);
             //判断是否超限
-            updateCharsWhenExceedLimit(counter, request.getShopName(), remainingChars, new TranslateRequest(0, null, request.getAccessToken(), source, target, null));
+            updateCharsWhenExceedLimit(counter, request.getShopName(), remainingChars, new TranslateRequest(0, null, request.getAccessToken(), registerTransactionRequest.getLocale(), target, null));
             //获取缓存数据
             String targetCache = translateSingleLine(value, request.getTarget());
             if (targetCache != null) {
@@ -822,11 +818,11 @@ public class TranslateService {
                 continue;
             }
 
-//            谷歌翻译
+//            首选谷歌翻译，翻译不了用AI翻译
             try {
-                counter.addChars(calculateToken(value, 1));
-                String targetString = getGoogleTranslateData(new TranslateRequest(0, null, request.getAccessToken(), registerTransactionRequest.getLocale(), request.getTarget(), value));
-                saveToShopify(targetString, translation, resourceId, request);
+                //TODO: 修改为判断语言代码的方法
+//                String targetString = getGoogleTranslateData(new TranslateRequest(0, null, request.getAccessToken(), registerTransactionRequest.getLocale(), request.getTarget(), value));
+                translateByGoogleOrAI(request, counter, aiLanguagePacksDO, registerTransactionRequest, translation);
             } catch (Exception e) {
                 appInsights.trackTrace("翻译失败后的字符数： " + counter.getTotalChars());
                 translationCounterService.updateUsedCharsByShopName(new TranslationCounterRequest(0, request.getShopName(), 0, counter.getTotalChars(), 0, 0, 0));
@@ -836,20 +832,19 @@ public class TranslateService {
         }
     }
 
-    private String translateWithAPI(String value, RegisterTransactionRequest registerTransactionRequest, ShopifyRequest request, CharacterCountUtils counter, TranslateContext translateContext) throws Exception {
-        String targetString = null;
 
-        if (value.length() > 40) {
-            // AI翻译
-            aiTranslateApi(createTranslationMap(request.getTarget(), registerTransactionRequest), registerTransactionRequest, request, translateContext.getAiLanguagePacksDO(), counter);
-        } else {
-            // Google翻译
-            counter.addChars(calculateToken(value, 1));
-            targetString = getGoogleTranslateData(new TranslateRequest(0, null, request.getAccessToken(), registerTransactionRequest.getLocale(), request.getTarget(), value));
-            addData(request.getTarget(), value, targetString);
+    //首选谷歌翻译，翻译不了用AI翻译
+    public void translateByGoogleOrAI(ShopifyRequest request, CharacterCountUtils counter, AILanguagePacksDO aiLanguagePacksDO, RegisterTransactionRequest registerTransactionRequest, Map<String, Object> translation) {
+        String value = registerTransactionRequest.getValue();
+        List<String> strings = jsoupUtils.googleTranslateJudgeCode(new TranslateRequest(0, null, request.getAccessToken(), registerTransactionRequest.getLocale(), request.getTarget(), value), aiLanguagePacksDO);
+        String targetString = strings.get(0);
+        String flag = strings.get(1);
+        if ("0".equals(flag)) {
+            counter.addChars(calculateToken(aiLanguagePacksDO.getPromotWord() + value, aiLanguagePacksDO.getDeductionRate()));
+            counter.addChars(calculateToken(targetString, aiLanguagePacksDO.getDeductionRate()));
         }
-
-        return targetString;
+        counter.addChars(calculateToken(value, 1));
+        saveToShopify(targetString, translation, registerTransactionRequest.getResourceId(), request);
     }
 
     //创建存储翻译项的Map
@@ -861,30 +856,6 @@ public class TranslateService {
         return translation;
     }
 
-    //根据chooseData来判断用什么翻译API
-    private void aiTranslateApi(Map<String, Object> translation, RegisterTransactionRequest registerTransactionRequest, ShopifyRequest request, AILanguagePacksDO aiLanguagePacksDO, CharacterCountUtils counter) {
-        String resourceId = registerTransactionRequest.getResourceId();
-        String value = registerTransactionRequest.getValue();
-        String target = request.getTarget();
-        String source = registerTransactionRequest.getLocale();
-        String targetString;
-        // 对翻译的文本做判断
-        try {
-            //用AI翻译
-            counter.addChars(calculateToken(value + aiLanguagePacksDO.getPromotWord(), aiLanguagePacksDO.getDeductionRate()));
-            targetString = chatGptIntegration.chatWithGpt(aiLanguagePacksDO.getPromotWord() + value);
-            counter.addChars(calculateToken(targetString, aiLanguagePacksDO.getDeductionRate()));
-        } catch (Exception e) {
-            // 如果AI翻译失败，则使用谷歌翻译
-            targetString = getGoogleTranslateData(new TranslateRequest(0, null, request.getAccessToken(), source, target, value));
-            addData(target, value, targetString);
-            saveToShopify(targetString, translation, resourceId, request);
-            return;
-        }
-
-        addData(target, value, targetString);
-        saveToShopify(targetString, translation, resourceId, request);
-    }
 
     //将获得的TRANSLATION_RESOURCES数据进行判断 存储到不同集合， 对不同集合的数据进行特殊处理
     private void judgeAndStoreData(ArrayNode contentNode, String resourceId, Map<String, List<RegisterTransactionRequest>> judgeData,

--- a/src/main/java/com/bogdatech/model/controller/request/GoogleAndAIRequest.java
+++ b/src/main/java/com/bogdatech/model/controller/request/GoogleAndAIRequest.java
@@ -1,0 +1,17 @@
+package com.bogdatech.model.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoogleAndAIRequest {
+    private String promotWord;
+    private Integer deductionRate;
+    private String source;
+    private String target;
+    private String content;
+
+}

--- a/src/main/java/com/bogdatech/task/RateTask.java
+++ b/src/main/java/com/bogdatech/task/RateTask.java
@@ -5,10 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 
 @Component
 @EnableScheduling
@@ -20,8 +17,8 @@ public class RateTask {
     public RateTask(RateHttpIntegration rateHttpIntegration) {
         this.rateHttpIntegration = rateHttpIntegration;
     }
-    @PostConstruct
-    @Scheduled(cron = "0 15 1 ? * *")
+//    @PostConstruct
+//    @Scheduled(cron = "0 15 1 ? * *")
     @Async
     public void getRateEveryHour() {
 //        System.out.println(LocalDateTime.now() + " getRateEveryHour " + Thread.currentThread().getName());

--- a/src/main/java/com/bogdatech/task/RateTask.java
+++ b/src/main/java/com/bogdatech/task/RateTask.java
@@ -5,7 +5,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 @EnableScheduling
@@ -17,8 +20,8 @@ public class RateTask {
     public RateTask(RateHttpIntegration rateHttpIntegration) {
         this.rateHttpIntegration = rateHttpIntegration;
     }
-//    @PostConstruct
-//    @Scheduled(cron = "0 15 1 ? * *")
+    @PostConstruct
+    @Scheduled(cron = "0 15 1 ? * *")
     @Async
     public void getRateEveryHour() {
 //        System.out.println(LocalDateTime.now() + " getRateEveryHour " + Thread.currentThread().getName());

--- a/src/main/java/com/bogdatech/utils/JsoupUtils.java
+++ b/src/main/java/com/bogdatech/utils/JsoupUtils.java
@@ -14,10 +14,7 @@ import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.bogdatech.logic.TranslateService.SINGLE_LINE_TEXT;
 import static com.bogdatech.logic.TranslateService.addData;
@@ -191,7 +188,7 @@ public class JsoupUtils {
 
     //对文本进行翻译（通用）
     public Map<Element, List<String>> translateTexts(Map<Element, List<String>> elementTextMap, TranslateRequest request,
-                                                     CharacterCountUtils counter) {
+                                                     CharacterCountUtils counter, AILanguagePacksDO aiLanguagePacksDO) {
         Map<Element, List<String>> translatedTextMap = new HashMap<>();
         for (Map.Entry<Element, List<String>> entry : elementTextMap.entrySet()) {
             Element element = entry.getKey();
@@ -199,15 +196,13 @@ public class JsoupUtils {
             List<String> translatedTexts = new ArrayList<>();
             for (String text : texts) {
                 String translated = translateSingleLine(text, request.getTarget());
-                counter.addChars(calculateToken(text, 1));
                 if (translated != null) {
+                    counter.addChars(calculateToken(text, 1));
                     translatedTexts.add(translated);
                 } else {
                     request.setContent(text);
-                    String targetString = translateApiIntegration.googleTranslate(request);
-//                    String targetString = translateApiIntegration.microsoftTranslate(request);
-                    addData(request.getTarget(), text, targetString);
-                    translatedTexts.add(targetString);
+                    //TODO： 目前没有翻译html的提示词，用的是谷歌翻译
+                    translateAndCount(request, counter, aiLanguagePacksDO, translatedTexts);
                 }
             }
             translatedTextMap.put(element, translatedTexts); // 保存翻译后的文本和 alt 属性
@@ -277,37 +272,44 @@ public class JsoupUtils {
         return null;
     }
 
-    //TODO：调用google翻译前需要先判断 是否是google支持的语言 如果不支持改用AI翻译
-    public String googleTranslateJudgeCode(TranslateRequest request, AILanguagePacksDO aiLanguagePacksDO) {
+    //调用google翻译前需要先判断 是否是google支持的语言 如果不支持改用AI翻译
+    public List<String> googleTranslateJudgeCode(TranslateRequest request, AILanguagePacksDO aiLanguagePacksDO) {
         String target = request.getTarget();
         String source = request.getSource();
-        if (googleTransformCode.contains(target) || googleTransformCode.contains(source)) {
-            return chatGptIntegration.chatWithGpt(aiLanguagePacksDO.getPromotWord() + request.getContent());
+        List<String> result = new ArrayList<>();
+        if (LANGUAGE_CODES.contains(target) || LANGUAGE_CODES.contains(source)) {
+            String s = chatGptIntegration.chatWithGpt(aiLanguagePacksDO.getPromotWord() + request.getContent());
+            result.add(s);
+            result.add("0");
+            return result;
         }
-        return translateApiIntegration.googleTranslate(request);
+        String s = translateApiIntegration.googleTranslate(request);
+//        String s = translateApiIntegration.microsoftTranslate(request);
+        result.add(s);
+        result.add("1");
+        return result;
     }
 
-    public  String googleTransformCode = """
-               ce
-               kw
-               fo
-               ia
-               kl
-               ks
-               ki
-               lu
-               gv
-               nd
-               se
-               nb
-               nn
-               os
-               rm
-               sc
-               ii
-               bo
-               to
-               wo""";
+    //在调用googleTranslateJudgeCode的基础上添加计数功能,并添加到翻译后的文本
+    public void translateAndCount(TranslateRequest request,
+                                  CharacterCountUtils counter, AILanguagePacksDO aiLanguagePacksDO, List<String> translatedTexts){
+        String text = request.getContent();
+        List<String> strings = googleTranslateJudgeCode(request, aiLanguagePacksDO);
+        String targetString = strings.get(0);
+        String flag = strings.get(1);
+        if ("0".equals(flag)) {
+            counter.addChars(calculateToken(aiLanguagePacksDO.getPromotWord() + text, aiLanguagePacksDO.getDeductionRate()));
+            counter.addChars(calculateToken(targetString, aiLanguagePacksDO.getDeductionRate()));
+        }
+        counter.addChars(calculateToken(text, 1));
+        addData(request.getTarget(), text, targetString);
+        translatedTexts.add(targetString);
+    }
+    // 定义语言代码集合
+    private static final Set<String> LANGUAGE_CODES = new HashSet<>(Arrays.asList(
+            "ce", "kw", "fo", "ia", "kl", "ks", "ki", "lu", "gv", "nd",
+            "se", "nb", "nn", "os", "rm", "sc", "ii", "bo", "to", "wo", "ar-EG"
+    ));
 
 
 }


### PR DESCRIPTION
1，新建googleAndAIRequest，便于调用judgeLanguageAPI
2，实现translateByGoogleOrAI用于普通文本的翻译
3，实现translateAndCount用于html文本的翻译
4，实现translateHtml用于openAI翻译