### PR TITLE
1，修改翻译规则：

### DIFF
--- a/src/main/java/com/bogdatech/logic/RabbitMqTranslateService.java
+++ b/src/main/java/com/bogdatech/logic/RabbitMqTranslateService.java
@@ -550,6 +550,12 @@ public class RabbitMqTranslateService {
                     iterator.remove();
                     continue;
                 }
+                //如果是base64编码的数据，不翻译
+                if (BASE64_PATTERN.matcher(value).matches()) {
+                    printTranslateReason(value + "是base64编码的数据, key是： " + key);
+                    iterator.remove();
+                    continue;
+                }
                 if (isJson(value)) {
                     iterator.remove();
                     continue;

--- a/src/main/java/com/bogdatech/logic/ShopifyService.java
+++ b/src/main/java/com/bogdatech/logic/ShopifyService.java
@@ -322,6 +322,11 @@ public class ShopifyService {
                 if (!metaTranslate(value)) {
                     continue;
                 }
+                //如果是base64编码的数据，不翻译
+                if (BASE64_PATTERN.matcher(value).matches()) {
+                    printTranslateReason(value + "是base64编码的数据, key是： " + key);
+                    continue;
+                }
                 counter.addChars(calculateModelToken(value));
                 continue;
             }
@@ -488,6 +493,11 @@ public class ShopifyService {
                     continue;
                 }
                 if (!metaTranslate(value)) {
+                    continue;
+                }
+                //如果是base64编码的数据，不翻译
+                if (BASE64_PATTERN.matcher(value).matches()) {
+                    printTranslateReason(value + "是base64编码的数据, key是： " + key);
                     continue;
                 }
                 counter.addChars(calculateModelToken(value));

--- a/src/main/java/com/bogdatech/logic/TranslateService.java
+++ b/src/main/java/com/bogdatech/logic/TranslateService.java
@@ -1343,7 +1343,11 @@ public class TranslateService {
                     printTranslateReason(value + " 包含top,left,right,bottom，在METAFIELD模块");
                     continue;
                 }
-
+                //如果是base64编码的数据，不翻译
+                if (BASE64_PATTERN.matcher(value).matches()) {
+                    printTranslateReason(value + "是base64编码的数据, key是： " + key);
+                    continue;
+                }
                 judgeData.get(METAFIELD).add(new RegisterTransactionRequest(shopName, null, locale, key, value, translatableContentDigest, resourceId, type));
                 continue;
             }

--- a/src/main/java/com/bogdatech/utils/JudgeTranslateUtils.java
+++ b/src/main/java/com/bogdatech/utils/JudgeTranslateUtils.java
@@ -135,7 +135,7 @@ public class JudgeTranslateUtils {
     private static final Pattern EMAIL_PATTERN = Pattern.compile(
             "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
     );//包含邮箱
-    private static final Pattern BASE64_PATTERN = Pattern.compile("^(?=[A-Za-z0-9+/]*[A-Z])(?=[A-Za-z0-9+/]*[a-z])(?=[A-Za-z0-9+/]*[0-9])(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"); // Base64编码
+    public static final Pattern BASE64_PATTERN = Pattern.compile("^(?=[A-Za-z0-9+/]*[A-Z])(?=[A-Za-z0-9+/]*[a-z])(?=[A-Za-z0-9+/]*[0-9])(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"); // Base64编码
     private static final Pattern HASH_PATTERN = Pattern.compile("^[a-fA-F0-9]{64}$"); // 32位十六进制字符串
     // 长度限制常量
     private static final int HASH_PREFIX_MAX_LENGTH = 90;
@@ -165,6 +165,12 @@ public class JudgeTranslateUtils {
         // 包含/，且长度不超过20
         if (value.contains("/") && value.length() <= SLASH_CONTAINS_MAX_LENGTH) {
             printTranslateReason(value + "包含/，且长度不超过20, key是： " + key);
+            return false;
+        }
+
+        //如果是base64编码的数据，不翻译
+        if (BASE64_PATTERN.matcher(value).matches()) {
+            printTranslateReason(value + "是base64编码的数据, key是： " + key);
             return false;
         }
 
@@ -298,11 +304,6 @@ public class JudgeTranslateUtils {
             return false;
         }
 
-        //如果是base64编码的数据，不翻译
-        if (BASE64_PATTERN.matcher(value).matches()) {
-            printTranslateReason(value + "是base64编码的数据, key是： " + key);
-            return false;
-        }
 
         //如果是32位十六进制字符串值，不翻译
         if (HASH_PATTERN.matcher(value).matches()) {


### PR DESCRIPTION
1）删除包含.json且包含 css 的字符
2）删除包含_link的字符
3）只在secton.和general.中判断是否“包含/，且长度不超过20”
4）在主题general/section里面，
key值判断的白名单必须在黑名单之前
5)base64编码判断只在元字段和主题生效