### PR TITLE
1,免费试用直接加额度, 对免费试用进行判断，是修改免费试用状态为true，不是，存入相关数据 2,卸载后只减免费试用额度 3,免费试用不发邮件

### DIFF
--- a/src/main/java/com/bogdatech/logic/OrderService.java
+++ b/src/main/java/com/bogdatech/logic/OrderService.java
@@ -89,7 +89,7 @@ public class OrderService {
         UserTrialsDO userTrialsDO = iUserTrialsService.getOne(new LambdaQueryWrapper<UserTrialsDO>().eq(UserTrialsDO::getShopName, charsOrdersDO.getShopName()));
         if (userTrialsDO != null && !userTrialsDO.getIsTrialExpired()) {
             appInsights.trackTrace("sendSubscribeSuccessEmail: " + charsOrdersDO.getShopName() + " is free trial");
-            return true;
+            return false;
         }
         //根据shopName获取用户名
         UsersDO usersDO = usersService.getUserByName(charsOrdersDO.getShopName());

--- a/src/main/java/com/bogdatech/logic/TranslationCounterService.java
+++ b/src/main/java/com/bogdatech/logic/TranslationCounterService.java
@@ -60,7 +60,7 @@ public class TranslationCounterService {
         Integer trialDays = queryValid.getInteger("trialDays");
         appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 免费试用天数 ：" + trialDays);
         Integer charsByPlanName = iSubscriptionPlansService.getCharsByPlanName(name);
-        if (name.equals(charsOrdersDO.getName()) && status.equals(charsOrdersDO.getStatus()) && trialDays > 0){
+        if (name.equals(charsOrdersDO.getName()) && status.equals(charsOrdersDO.getStatus()) && trialDays >= 0){
             appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 第一次免费试用 ：" + translationCharsVO.getSubGid());
             // 不添加额度, 但需要修改免费试用订阅表
             String createdAt = queryValid.getString("createdAt");

--- a/src/main/java/com/bogdatech/logic/TranslationCounterService.java
+++ b/src/main/java/com/bogdatech/logic/TranslationCounterService.java
@@ -61,7 +61,7 @@ public class TranslationCounterService {
         appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 免费试用天数 ：" + trialDays);
         Integer charsByPlanName = iSubscriptionPlansService.getCharsByPlanName(name);
         if (name.equals(charsOrdersDO.getName()) && status.equals(charsOrdersDO.getStatus()) && trialDays >= 0){
-            appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 第一次免费试用 ：" + translationCharsVO.getSubGid());
+//            appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 第一次免费试用 ：" + translationCharsVO.getSubGid());
             // 不添加额度, 但需要修改免费试用订阅表
             String createdAt = queryValid.getString("createdAt");
             //用户购买订阅时间


### PR DESCRIPTION
1,免费试用直接加额度, 对免费试用进行判断，是修改免费试用状态为true，不是，存入相关数据
2,卸载后只减免费试用额度
3,免费试用不发邮件