### PR TITLE
1,免费试用直接加额度, 对免费试用进行判断，是修改免费试用状态为true，不是，存入相关数据

### DIFF
--- a/src/main/java/com/bogdatech/logic/TranslationCounterService.java
+++ b/src/main/java/com/bogdatech/logic/TranslationCounterService.java
@@ -60,7 +60,7 @@ public class TranslationCounterService {
         Integer trialDays = queryValid.getInteger("trialDays");
         appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 免费试用天数 ：" + trialDays);
         Integer charsByPlanName = iSubscriptionPlansService.getCharsByPlanName(name);
-        if (name.equals(charsOrdersDO.getName()) && status.equals(charsOrdersDO.getStatus()) && trialDays >= 0){
+        if (name.equals(charsOrdersDO.getName()) && status.equals(charsOrdersDO.getStatus()) && trialDays > 0){
 //            appInsights.trackTrace("addCharsByShopNameAfterSubscribe " + shopName + " 用户 第一次免费试用 ：" + translationCharsVO.getSubGid());
             // 不添加额度, 但需要修改免费试用订阅表
             String createdAt = queryValid.getString("createdAt");
@@ -76,10 +76,9 @@ public class TranslationCounterService {
                 iUserTrialsService.save(new UserTrialsDO(null, shopName, beginTimestamp, afterTrialDaysTimestamp, false));
                 //修改额度表里面数据，用于该用户卸载，和扣额度. 暂定openaiChar为1是免费试用
                 iTranslationCounterService.update(new LambdaUpdateWrapper<TranslationCounterDO>().eq(TranslationCounterDO::getShopName, shopName).set(TranslationCounterDO::getGoogleChars, charsByPlanName).set(TranslationCounterDO::getOpenAiChars,1));
-            }else {
-                iUserTrialsService.update(new LambdaUpdateWrapper<UserTrialsDO>().eq(UserTrialsDO::getShopName, shopName).set(UserTrialsDO::getIsTrialExpired, true));
             }
-
+        }else {
+            iUserTrialsService.update(new LambdaUpdateWrapper<UserTrialsDO>().eq(UserTrialsDO::getShopName, shopName).set(UserTrialsDO::getIsTrialExpired, true));
         }
 
         //添加额度


### PR DESCRIPTION
2,卸载后只减免费试用额度
3,免费试用不发邮件